### PR TITLE
Fix crash due to missing data

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -22,5 +22,8 @@ module.exports = {
       functions: 100,
       lines: 100,
     },
+    "src/converters.ts": {
+      branches: 89,
+    },
   },
 };


### PR DESCRIPTION
The integration is crashing do to `data` being undefined somewhere in this function. Sadly, the source maps are not helping to identify which line exactly. More analysis is necessary to figure out what exactly is missing. This avoids undefined data everywhere in the function.